### PR TITLE
[FIX] Fixes add_peaks() functionality

### DIFF
--- a/peakdet/editor.py
+++ b/peakdet/editor.py
@@ -35,7 +35,10 @@ class _PhysioEditor():
         self.fig.canvas.mpl_connect('scroll_event', self.on_wheel)
         self.fig.canvas.mpl_connect('key_press_event', self.on_key)
 
-        # three selectors for rejection (left mouse), addition (central mouse), and deletion (right mouse)
+        # three selectors for:
+        #    1. rejection (left mouse),
+        #    2. addition (central mouse), and
+        #    3. deletion (right mouse)
         reject = functools.partial(self.on_edit, reject=True)
         delete = functools.partial(self.on_edit, reject=False)
         include = functools.partial(self.on_edit, reject=False, insert=True)
@@ -98,19 +101,21 @@ class _PhysioEditor():
         """
 
         if reject and insert:
-            raise Exception('Selected to both reject and insert! Program goes kaput.')
+            raise ValueError('Cannot select both reject and insert!')
 
         tmin, tmax = np.searchsorted(self.time, (xmin, xmax))
         pmin, pmax = np.searchsorted(self.data.peaks, (tmin, tmax))
 
         if insert:
-            temp_peak = np.argmax(self.data.data[tmin:tmax])
-            if temp_peak == 0:
+            tmp = np.argmax(self.data.data[tmin:tmax]) if tmin != tmax else 0
+            newpeak = tmin + tmp
+            if newpeak == tmin:
+                self.plot_signals()
                 return
-            newpeak = [tmin + temp_peak]
         else:
             bad = np.arange(pmin, pmax, dtype=int)
             if len(bad) == 0:
+                self.plot_signals()
                 return
 
         if reject:
@@ -121,7 +126,7 @@ class _PhysioEditor():
         # store edits in local history & call function
         if insert:
             self.included.add(newpeak)
-            self.data = operations.add_peaks(self.data, newpeak, pmin)
+            self.data = operations.add_peaks(self.data, newpeak)
         else:
             rej.update(self.data.peaks[bad].tolist())
             self.data = fcn(self.data, self.data.peaks[bad])
@@ -131,7 +136,8 @@ class _PhysioEditor():
     def undo(self):
         """ Resets last span select peak removal """
         # check if last history entry was a manual reject / delete
-        if self.data._history[-1][0] not in ['reject_peaks', 'delete_peaks']:
+        relevant = ['reject_peaks', 'delete_peaks', 'add_peaks']
+        if self.data._history[-1][0] not in relevant:
             return
 
         # pop off last edit and delete
@@ -149,7 +155,12 @@ class _PhysioEditor():
                 peaks['remove']
             )
             self.deleted.difference_update(peaks['remove'])
-
+        elif func == 'add_peaks':
+            self.data._metadata['peaks'] = np.delete(
+                self.data._metadata['peaks'],
+                np.searchsorted(self.data._metadata['peaks'], peaks['add']),
+            )
+            self.included.remove(peaks['add'])
         self.data._metadata['troughs'] = utils.check_troughs(self.data,
                                                              self.data.peaks)
         self.plot_signals()

--- a/peakdet/operations.py
+++ b/peakdet/operations.py
@@ -183,7 +183,7 @@ def reject_peaks(data, remove):
 
 
 @utils.make_operation()
-def add_peaks(data, newpeak, pins):
+def add_peaks(data, add):
     """
     Add `newpeak` to add them in `data`
 
@@ -191,6 +191,7 @@ def add_peaks(data, newpeak, pins):
     ----------
     data : Physio_like
     newpeak : int
+    pins : int
 
     Returns
     -------
@@ -198,7 +199,8 @@ def add_peaks(data, newpeak, pins):
     """
 
     data = utils.check_physio(data, ensure_fs=False, copy=True)
-    data._metadata['peaks'] = np.insert(data._metadata['peaks'], pins, newpeak)
+    idx = np.searchsorted(data._metadata['peaks'], add)
+    data._metadata['peaks'] = np.insert(data._metadata['peaks'], idx, add)
     data._metadata['troughs'] = utils.check_troughs(data, data.peaks)
 
     return data
@@ -228,13 +230,14 @@ def edit_physio(data):
     # perform manual editing
     edits = editor._PhysioEditor(data)
     plt.show(block=True)
-    delete, reject = sorted(edits.deleted), sorted(edits.rejected)
 
     # replay editing on original provided data object
-    if reject is not None:
-        data = reject_peaks(data, remove=reject)
-    if delete is not None:
-        data = delete_peaks(data, remove=delete)
+    if len(edits.rejected) > 0:
+        data = reject_peaks(data, remove=sorted(edits.rejected))
+    if len(edits.deleted) > 0:
+        data = delete_peaks(data, remove=sorted(edits.deleted))
+    if len(edits.included) > 0:
+        data = add_peaks(data, add=sorted(edits.included))
 
     return data
 


### PR DESCRIPTION
Hey @smoia! :wave:

So I needed to actually play around with the code to figure out what was happening, thus this PR to your PR with the changes I made after messing around with stuff! I _think_ I've got the functionality working (more-or-less), but figured I'd write out what was changed (and a brief description of why). Let me know if you have questions about this!

### Changes 

My biggest issue (at first) was just getting the "scroll wheel button press + drag" to work on my Macbook. I...never figured that out, so for testing I switched which buttons were tied to which functions (but obviously changed it back for this PR). Nonetheless, that's something to consider for those of us who (are in the dark ages and) don't have an actual physical mouse to use (beyond the laptop trackpad)—this functionality may be inaccessible!

Moving on to the code that needed to get changed to make things work: your set issue was because you were trying to `set.add()` a list to a set. Granted, it was a list of length one with an int in it, but still a list (a call to `set.update()` would have worked in that case). I've removed this issue by just making `newpeak` an int, since you can only add one peak at a time.

I also modified the `add_peak()` function for a few reasons: (1) it's nice to only have one input (besides the data), and (2) the actual editing of the `physio` objects happens in the `edit_physio()` function, where we _only_ have access to the added peak, not the location of the peak! 

Finally, I updated the `Editor.undo()` command so you can undo adding peaks! This simply deletes the peak that was last added from the array, and removes it from the `self.included` set so we don't consider it anymore!

### Suggestions

1. I might change the `Editor.on_edit()` function so that rather than using the `reject` and `insert` boolean parameters it can take a single parameter that accepts a string ('reject', 'delete', 'insert') and use those to guide the workflow. The whole "if insert" vs "if reject" vs "if not insert" is a bit much to follow and I think one parameter (`method`?) might be easier.

2. Since you can now add peaks, you may want to find a way to visually display "rejected" peaks—since you cannot re-add peaks you have just rejected (since a rejected peak still exists but is just being ignored; note that you can re-add peaks you've deleted!). You could do this by changing the marker denoting a rejected peak from a red dot to a red x (or something like that?) This would just require a few extra lines of code in the `Editor.plot_signals()` function and would probably be beneficial for people.

3. Rather than having to add each peak individually it might be nice to perform a little peak finding algorithm over the highlighted area. As is, if _several_ peaks are missed in a row you need to add each individually (several clicks). If you actually call a peakfinding algorithm on the highlighted area and add the detected peaks that might help solve that issue! This could raise new issues, too, but just a thought.

---

Anyway, as I said, let me know if you have any questions about this! Feel free to merge into your PR and continue making changes, as necessary. Hopefully this helps!